### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,5 @@ require (
 	github.com/Monibuca/utils/v3 v3.0.0-alpha5
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/pion/rtp v1.6.5 // indirect
-	golang.org/x/sync v0.0.0-2021501223332-0cec33c27-c8c // indirec
-	olang.org/x/sys v0.0.0-20210521203332-0cec03c779c1 // indirect
+	golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1 // indirect
 )


### PR DESCRIPTION
解决 golang.org/x/sync@v0.0.0-2021501223332-0cec33c27-c8c: unrecognized import path "golang.org/x/sync": 问题